### PR TITLE
Add uva create dataset (test)

### DIFF
--- a/uva/create/.htaccess
+++ b/uva/create/.htaccess
@@ -1,0 +1,23 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+#AddType application/rdf+xml .rdf
+#AddType text/turtle .ttl
+#AddType application/n-triples .nt
+#AddType application/ld+json .json
+
+RewriteEngine on
+
+#Rewrite rules
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^.*$ https://www.create.humanities.uva.nl/  [R=303,NE,L]
+
+

--- a/uva/create/README.md
+++ b/uva/create/README.md
@@ -1,0 +1,10 @@
+# Datsets built by CREATE
+
+CREATE's URI is: https://resolver-acc.clariah.nl/uva/create/, which redirects to https://www.create.humanities.uva.nl/.
+
+Datasets using this service:
+
+* Notarissennetwerk (`https://resolver-acc.clariah.nl/uva/create/notarissennetwerk/`)
+
+## Contact
+* CREATE Lab (createlab@uva.nl)

--- a/uva/create/notarissennetwerk/.htaccess
+++ b/uva/create/notarissennetwerk/.htaccess
@@ -1,0 +1,23 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+#AddType application/rdf+xml .rdf
+#AddType text/turtle .ttl
+#AddType application/n-triples .nt
+#AddType application/ld+json .json
+
+RewriteEngine on
+
+#Rewrite rules
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^.*\/(?:person|personname|event|role|address|)\/(\d+)(?:-.*)?$ https://notarissennetwerk.nl/notaris/$1  [R=303,NE,L]
+RewriteRule ^.*$ https://notarissennetwerk.nl/  [R=303,NE,L]
+

--- a/uva/create/notarissennetwerk/README.md
+++ b/uva/create/notarissennetwerk/README.md
@@ -1,0 +1,9 @@
+# URIs for the Notarissennetwerk
+`https://resolver-acc.clariah.nl/uva/create/notarissennetwerk/`
+
+This service is used to generate URIs for persons, personnames, events, roles, and addresses. For now, these are redirected to the respective notary's page on https://notarissennetwerk.nl/.
+
+TODO: Content negotiation.
+
+## Contact
+* Leon van Wissen (l.vanwissen@uva.nl)


### PR DESCRIPTION
Added to the resolver:
* A folder on the institutional level `/uva/`
* A folder on the organisation level `/uva/create/`
* A folder on the dataset level `/uva/create/notarissennetwerk/`

Thereby:
* A URI is created for CREATE: https://resolver-acc.clariah.nl/uva/create/
* URIs are redirected for this dataset: e.g. https://resolver-acc.clariah.nl/uva/create/notarissennetwerk/person/2211

NB: All URIs in the READMEs are now using the `resolver-acc` subdomain and should be changed when this goes live. 
